### PR TITLE
Feat/debounce on keypress

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,5 @@ const App = () => {
     );
 };
 ```
+
+- If you want to take a look at a list of all the keys for different platforms, you can use the following [link](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ const App = () => {
 <sub>It is recommended that you place the provider at the beginning of the component tree.
 </sub>
 
+<sub>By default, the provider will have a debounce on key presses events of 1000ms, you can change this value by passing the `debounce` prop to the provider</sub>
+
+```tsx
+const App = () => {
+  return (
+          <KeyBindProvider debounce={500}>
+            hello world
+          </KeyBindProvider>
+  );
+}
+```
+
 ### 2. Global shortcuts
 
 You can register commands globally

--- a/src/context/KeyBindContext.tsx
+++ b/src/context/KeyBindContext.tsx
@@ -19,6 +19,7 @@ export const KeyBindContext = createContext({} as KeyBindContextState);
 const KeyBindProvider: FC<KeyBindProviderPropsI> = ({
   children,
   shortcuts = [],
+  debounce,
   debug = false,
 }) => {
   const [storeShortcuts, setStoreCommands] = useState(shortcuts);
@@ -48,7 +49,7 @@ const KeyBindProvider: FC<KeyBindProviderPropsI> = ({
     [storeShortcuts]
   );
 
-  useShortcuts(storeShortcuts);
+  useShortcuts(storeShortcuts, debounce);
 
   const commandsContext = useMemo<KeyBindContextState>(
     () => ({

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -1,14 +1,14 @@
-import { useEffect, useState } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
-import { findShortcut, hasItems } from '../utils';
-import { ShortcutType } from '../types';
+import {useEffect, useState} from 'react';
+import {useDebouncedCallback} from 'use-debounce';
+import {findShortcut, hasItems} from '../utils';
+import { ShortcutType} from '../types';
 
-export const useShortcuts = (shortcuts: ShortcutType[]) => {
+export const useShortcuts = (shortcuts: ShortcutType[], debounce?: number) => {
   const [keys, setKeys] = useState<string[]>([]);
 
   const removeKeys = useDebouncedCallback(() => {
     setKeys([]);
-  }, 1000);
+  }, debounce ?? 1000);
 
   useEffect(() => {
     if (hasItems(keys) && hasItems(shortcuts)) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export interface KeyBindProviderPropsI {
   children?: React.ReactNode;
   shortcuts?: ShortcutType[];
   debug?: boolean;
+  debounce?: number;
 }
 
 export type KeysType = {


### PR DESCRIPTION
Added debounce prop to KeybindProvider. Usage is as such:
![image](https://github.com/lifespikes/react-keybinds/assets/112645400/5065cab5-fe94-4bb1-a6d8-f87ba0057bd3)
